### PR TITLE
Add support for AppleCore's PlantGrowthEvent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
         name "Mobius Repo"
         url "http://mobiusstrip.eu/maven"
     }
+    maven {
+        name "squeek"
+        url "http://www.ryanliptak.com/maven/"
+    }
 }
 
 apply plugin: 'forge'
@@ -63,6 +67,9 @@ dependencies {
 
     // http://mobiusstrip.eu/maven
     compile "mcp.mobius.waila:Waila:1.5.5_1.7.10:dev"
+
+    // http://www.ryanliptak.com/maven/
+    compile "applecore:AppleCore:1.7.10-1.0.2+87.f5270:api"
 
     //some more mods
     compile fileTree(dir: 'libs', includes: ['*Mantle*.jar'])

--- a/src/main/java/com/InfinityRaider/AgriCraft/compatibility/applecore/AppleCoreHelper.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/compatibility/applecore/AppleCoreHelper.java
@@ -1,0 +1,46 @@
+package com.InfinityRaider.AgriCraft.compatibility.applecore;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import squeek.applecore.api.AppleCoreAPI;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.common.eventhandler.Event;
+
+public class AppleCoreHelper {
+    public static final String MODID = "AppleCore";
+    public static final boolean isAppleCoreLoaded = Loader.isModLoaded(AppleCoreHelper.MODID);
+    public static boolean hasDispatcher;
+    static {
+        try {
+            hasDispatcher = isAppleCoreLoaded && Class.forName("squeek.applecore.api.IAppleCoreDispatcher") != null;
+        } catch (ClassNotFoundException e) {
+            hasDispatcher = false;
+        }
+    }
+
+    @Optional.Method(modid = AppleCoreHelper.MODID)
+    private static Event.Result validateAppleCoreGrowthTick(Block block, World world, int x, int y, int z, Random random) {
+        return AppleCoreAPI.dispatcher.validatePlantGrowth(block, world, x, y, z, random);
+    }
+
+    @Optional.Method(modid = AppleCoreHelper.MODID)
+    private static void announceAppleCoreGrowthTick(Block block, World world, int x, int y, int z) {
+        AppleCoreAPI.dispatcher.announcePlantGrowth(block, world, x, y, z);
+    }
+
+    public static Event.Result validateGrowthTick(Block block, World world, int x, int y, int z, Random random) {
+        if (hasDispatcher)
+            return validateAppleCoreGrowthTick(block, world, x, y, z, random);
+        else
+            return Event.Result.DEFAULT;
+    }
+
+    public static void announceGrowthTick(Block block, World world, int x, int y, int z) {
+        if (hasDispatcher) {
+            announceAppleCoreGrowthTick(block, world, x, y, z);
+        }
+    }
+}


### PR DESCRIPTION
See:
* [Integrating crops with AppleCore](https://github.com/squeek502/AppleCore/wiki/Integrating-crops-with-AppleCore)
* https://github.com/squeek502/AppleCore/commit/f5270a6ab3a36c6abfb67b245f6e3b1aa76949b0

Note that this does *not* create a hard dependency on AppleCore, and only the AppleCore API is added to the development environment build path (through maven). This also should be backwards compatible with versions of AppleCore that don't have the newly added dispatcher.

Also, feel free to close this and treat it as an example implementation if you're not happy with my specific implementation.

* Closes #49