### PR TITLE
#130 -- Change timing of check for AppleCore API

### DIFF
--- a/src/main/java/com/InfinityRaider/AgriCraft/compatibility/ModIntegration.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/compatibility/ModIntegration.java
@@ -1,5 +1,6 @@
 package com.InfinityRaider.AgriCraft.compatibility;
 
+import com.InfinityRaider.AgriCraft.compatibility.applecore.AppleCoreHelper;
 import com.InfinityRaider.AgriCraft.compatibility.minefactoryreloaded.AgriCraftHarvestable;
 import com.InfinityRaider.AgriCraft.compatibility.minetweaker.*;
 import com.InfinityRaider.AgriCraft.compatibility.thaumcraft.Aspects;
@@ -15,6 +16,9 @@ import powercrystals.minefactoryreloaded.api.FactoryRegistry;
 public class ModIntegration {
 
     public static void init() {
+        // Apple Core
+        AppleCoreHelper.init();
+
         //Hunger Overhaul
         if(LoadedMods.hungerOverhaul) {
             FMLInterModComms.sendMessage("HungerOverhaul", "BlacklistRightClick", "com.InfinityRaider.AgriCraft.blocks.BlockCrop");

--- a/src/main/java/com/InfinityRaider/AgriCraft/compatibility/applecore/AppleCoreHelper.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/compatibility/applecore/AppleCoreHelper.java
@@ -11,7 +11,7 @@ import java.util.Random;
 
 public class AppleCoreHelper {
     public static final String MODID = "AppleCore";
-    public static final boolean isAppleCoreLoaded;
+    public static boolean isAppleCoreLoaded;
     public static boolean hasDispatcher;
 
     public static void init() {

--- a/src/main/java/com/InfinityRaider/AgriCraft/compatibility/applecore/AppleCoreHelper.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/compatibility/applecore/AppleCoreHelper.java
@@ -11,9 +11,11 @@ import java.util.Random;
 
 public class AppleCoreHelper {
     public static final String MODID = "AppleCore";
-    public static final boolean isAppleCoreLoaded = Loader.isModLoaded(AppleCoreHelper.MODID);
+    public static final boolean isAppleCoreLoaded;
     public static boolean hasDispatcher;
-    static {
+
+    public static void init() {
+        isAppleCoreLoaded = Loader.isModLoaded(AppleCoreHelper.MODID);
         try {
             hasDispatcher = isAppleCoreLoaded && Class.forName("squeek.applecore.api.IAppleCoreDispatcher") != null;
         } catch(ClassNotFoundException e) {


### PR DESCRIPTION
ModIntegration calls AppleCoreHelper.init rather than AppleCoreHelper depending on static initialization.