### PR TITLE
Fixed Shovel Interaction Bug

### DIFF
--- a/src/main/java/com/InfinityRaider/AgriCraft/handler/PlayerInteractEventHandler.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/handler/PlayerInteractEventHandler.java
@@ -57,6 +57,8 @@ public class PlayerInteractEventHandler {
             } else if(ModHelper.allowIntegration(Names.Mods.tconstruct) && TinkersConstructHelper.isShovel(event.entityPlayer.getCurrentEquippedItem())) {
                 flag = true;
             }
+            if(event.world.getBlock(event.x, event.y, event.z) != Blocks.farmland)
+                flag = false;
             if(flag) {
                 if (event.world.isRemote) {
                     denyEvent(event, true);


### PR DESCRIPTION
To go into further detail: Many people complain that when clicking on chests / crafting tables / doors / etc.., the swing is nullified, and sometimes other things too (like opening a GUI, the door open sound, etc.). This proposal changes flag to false if the block clicked is NOT a farmland block, preventing any other code that may result in this weirdness from occurring.