### PR TITLE
Fix long-standing "ignores Weeds Wipe Plants" setting

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
@@ -98,7 +98,7 @@ public class BlockCrop extends BlockBaseTile<TileEntityCrop> implements IGrowabl
         TileEntityCrop crop = (TileEntityCrop) world.getTileEntity(pos);
         if(crop.hasPlant() || crop.hasWeed()) {
             if (CompatibilityHandler.getInstance().allowGrowthTick(world, pos, this, crop, rnd)) {
-            	if (crop.isMature() && crop.hasWeed() && AgriCraftConfig.enableWeeds){
+            	if (crop.isMature() && crop.hasWeed() && AgriCraftConfig.enableWeeds && AgriCraftConfig.weedsWipePlants ){
                 	crop.spreadWeed();
                 }
             	else if (crop.isFertile()) {

--- a/src/main/java/com/infinityraider/agricraft/tileentity/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tileentity/TileEntityCrop.java
@@ -235,10 +235,12 @@ public class TileEntityCrop extends TileEntityBase implements ICrop, IDebuggable
     /** spawns WEED in the crop */
     @Override
     public void spawnWeed() {
-        this.crossCrop=false;
-        this.weed=true;
-        this.clearPlant();
-    }
+		( if this.getPlant != null && AgriCraftConfig.weedsWipePlants ) {
+			this.crossCrop=false;
+			this.weed=true;
+			this.clearPlant();
+		}
+	}
 
     /** spread the WEED */
     @Override


### PR DESCRIPTION
I have seen notes on the internet that AgriCraft has been ignoring this setting for a while and when testing recently found it to be the truth. This appears to be, mostly, a case of the configuration value never being checked after being read from the file. Changes have been made to the two locations that have a minimal amount of code needed to change, minimal chance of it being a crash cause and a high chance of solving this issue.
