### PR TITLE
Fixed CropPlantAgriCraftShearable not overriding the onHarvest that i…

### DIFF
--- a/src/main/java/com/InfinityRaider/AgriCraft/farming/cropplant/CropPlantAgriCraftShearable.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/farming/cropplant/CropPlantAgriCraftShearable.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemShears;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
 public class CropPlantAgriCraftShearable extends CropPlantAgriCraft {
@@ -19,6 +20,40 @@ public class CropPlantAgriCraftShearable extends CropPlantAgriCraft {
         this.meta = shearingResult.getItemDamage();
     }
 
+    @Override
+    public boolean onHarvest(World world, int x, int y, int z, com.InfinityRaider.AgriCraft.api.v3.ICrop crop, EntityPlayer player) {
+    	if(player == null) {
+            return true;
+        }
+        if(player.getCurrentEquippedItem() == null) {
+            return true;
+        }
+        if(player.getCurrentEquippedItem().getItem() == null) {
+            return true;
+        }
+        if(!(player.getCurrentEquippedItem().getItem() instanceof ItemShears)) {
+            return true;
+        }
+        
+        TileEntity tile = crop.getTileEntity();
+        tile.getWorldObj().setBlockMetadataWithNotify(tile.xCoord, tile.yCoord, tile.zCoord, 2, 2);
+        int amount = ((int) (Math.ceil((crop.getGain() + 0.00) / 3)))/2;
+        if(amount>0) {
+            ItemStack drop = new ItemStack(item, amount, meta);
+            if (world.getGameRules().getGameRuleBooleanValue("doTileDrops") && !world.restoringBlockSnapshots) {
+                float f = 0.7F;
+                double d0 = (double) (world.rand.nextFloat() * f) + (double) (1.0F - f) * 0.5D;
+                double d1 = (double) (world.rand.nextFloat() * f) + (double) (1.0F - f) * 0.5D;
+                double d2 = (double) (world.rand.nextFloat() * f) + (double) (1.0F - f) * 0.5D;
+                EntityItem entityitem = new EntityItem(world, (double) x + d0, (double) y + d1, (double) z + d2, drop);
+                entityitem.delayBeforeCanPickup = 10;
+                world.spawnEntityInWorld(entityitem);
+            }
+        }
+        player.getCurrentEquippedItem().damageItem(1, player);
+        return false;
+    }
+    
     @Override
     public boolean onHarvest(World world, int x, int y, int z, EntityPlayer player) {
         if(player == null) {


### PR DESCRIPTION
…ncludes an ICrop as a parameter. This was causing shears not to work.

Fixes #609
Fixes #590

NOTE: I re-implementsd onHarvest completely since the older one is marked as deprecated, but really the savings of avoiding a single call to world.getTileEntity almost doesn't seem worth it. I almost leaned toward just delegating the call to the existing onHarvest method. It might have been cleaner that way. Let me know if this is what you would prefer. If so, I will update the pull since I already have that code as well.